### PR TITLE
Makes bottom two drop downs not required to generate the link

### DIFF
--- a/check.js
+++ b/check.js
@@ -51,7 +51,7 @@ function checkDropdown(elementID, errorContainerID, parameterName){
     // error message container
     const errorContainer = document.getElementById(errorContainerID);
     // check input
-    if(element.value == "Select an option..."){
+    if(element.value == "Select an option..." && element.id == ("source"||"medium")){
       errorContainer.style.display = "block";
       errorContainer.textContent = "Please make sure one of the dropdown options is selected";
       errorContainer.closest("form").children[2].children[0].classList.add("error");


### PR DESCRIPTION
At the moment the bottom two "optional" drop downs are required to generate the link, but they shouldn't be. 

Slight side effect, you now get "&utm_term=select an option...&utm_content=select an option..." at the end of the link… 